### PR TITLE
minor code cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,7 @@
 execvar: main.c
 	gcc main.c -o execvar -ldl -Wall -Wextra
+
+.phony: clean
+
+clean:
+	rm execvar


### PR DESCRIPTION
Moved the long pointer arithmetic expression `block_header->sh_offset + count_addr - block_header->sh_addr` into a variable instead of repeating it twice. Cleaned up an unnecessarily complicated if expression (can just rely on unsigned underflow).